### PR TITLE
Remove unnecessary escapes + density

### DIFF
--- a/core/frontend/public/build/static/manifest.json
+++ b/core/frontend/public/build/static/manifest.json
@@ -2,10 +2,9 @@
  "name": "Djacket",
  "icons": [
   {
-   "src": "\/android-icon-36x36.png",
+   "src": "/android-icon-36x36.png",
    "sizes": "36x36",
-   "type": "image\/png",
-   "density": "0.75"
+   "type": "image/png"
   },
  ]
 }


### PR DESCRIPTION
There is no need to escape the strings for URLs or MIME type in the manifest. Additionally, a density of "0.75" won't ever match any device.
